### PR TITLE
header: increase size of eosDAC logo & menu font

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,7 @@
   <nav class="navbar fixed-top navbar-expand-lg navbar-dark bg-dark nav-tabs"
     style="background-image:linear-gradient(to right, #4A1289, #7C41BA)">
     <a class="navbar-brand" href="{% translate_link home %}">
-      <img src="/assets/signet-white.svg" height="30" alt="{% t site.title %}">
+      <img src="/assets/signet-white.svg" height="42" alt="{% t site.title %}">
     </a>
     <button class="navbar-toggler" type="button" data-toggle="collapse"
       data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false"

--- a/_sass/header.scss
+++ b/_sass/header.scss
@@ -4,9 +4,15 @@ nav.navbar {
 }
 .nav-tabs a.nav-link {
     text-transform: none;
+    font-size: 16px;
+    font-weight: 400;
+    padding: 19px 8px;
     @media (max-width: $break-point-mobile) {
         padding: 7px 0;
     }
+}
+.nav-tabs a.nav-link.active {
+    font-weight: 500;
 }
 .dropdown-menu a.dropdown-item {
     @media (max-width: $break-point-mobile) {


### PR DESCRIPTION
![header](https://user-images.githubusercontent.com/63956/53829470-88808a80-3f80-11e9-9835-5e106baeb23e.png)

This change increases the eosDAC logo in the header and the font-size of the menu items. as suggested by @nod74 