### PR TITLE
docs: enable local docs at http://localhost:4000/docs 

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  {%- include head.html -%}
+  <body>
+    <div class="container">
+      <div class="row">
+        <div class="col-md-12">
+          <h1><a href="/docs">Start</a> – eosDAC.io docs <small class="text-muted">(hosted version on <a href="https://github.com/eosdac/eosdacio-website/tree/master/docs">GitHub</a>)</small></h1>
+          <hr/>
+          <br/>
+        </div>
+      </div>
+    </div>
+    {{ content }}
+  </body>
+</html>

--- a/docs.html
+++ b/docs.html
@@ -1,0 +1,16 @@
+---
+layout: docs
+
+namespace: docs
+permalink: /docs/
+---
+<div class="docs">
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+          {% capture my_include %}{% include_relative docs/README.md %}{% endcapture %}
+          {{ my_include | markdownify | replace: ".md", "" }}
+      </div>
+    </div>
+  </div>
+</div>

--- a/docs/00-quickstart.html
+++ b/docs/00-quickstart.html
@@ -1,0 +1,16 @@
+---
+layout: docs
+
+namespace: docs-quickstart
+permalink: /docs/00-quickstart
+---
+<div class="docs">
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+          {% capture my_include %}{% include_relative 00-quickstart.md %}{% endcapture %}
+          {{ my_include | markdownify }}
+      </div>
+    </div>
+  </div>
+</div>

--- a/docs/01-translate.html
+++ b/docs/01-translate.html
@@ -1,0 +1,16 @@
+---
+layout: docs
+
+namespace: docs-translate
+permalink: /docs/01-translate
+---
+<div class="docs">
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+          {% capture my_include %}{% include_relative 01-translate.md %}{% endcapture %}
+          {{ my_include | markdownify }}
+      </div>
+    </div>
+  </div>
+</div>

--- a/docs/01-translate.md
+++ b/docs/01-translate.md
@@ -7,6 +7,13 @@ So if you would like to translate `section1` of the `how-to-vote` page ([_i18n/e
 
 Some general translations, such as site title, header menu or footer content, are done in a YAML file, located at `_i18n/LANGUAGE.yml`, please refer to [_i18n/en.yml](https://github.com/eosdac/eosdacio-website/blob/master/_i18n/en.yml) for all translateable keys.
 
+### Translate a blog posts
+Translation of blog posts inside `_i18n/en/_posts/` is very similar to the translation of pages. Each blog posts is contained in a separate file, e.g. `2019-02-11-eosdac-dactivation-day-is-here-feb-11th-2019.md`.
+* Create a file of the same name inside `_i18n/LANGUAGE/_posts/`
+* Copy the english post's meta-data ([front matter](https://jekyllrb.com/docs/front-matter/)) and translate the `title` field.
+* If there is a fully translated version of this posts, adopt the `external_link` field to point to the translated version, otherwise keep the link to the english version.
+* Translate the first paragraph (up to 400 characters) of the blog post into your LANGUAGE. We only show the abstract (first paragraph), so you do not need to translate the whole article.
+
 ### Checking translation status
 We are providing a scripts, which help to identify content in need of a (updated) translation.
 * `show_files_to_be_translated.sh` inside the `_i18n/` folder

--- a/docs/02-create-page.html
+++ b/docs/02-create-page.html
@@ -1,0 +1,16 @@
+---
+layout: docs
+
+namespace: docs-create-page
+permalink: /docs/02-create-page
+---
+<div class="docs">
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+          {% capture my_include %}{% include_relative 02-create-page.md %}{% endcapture %}
+          {{ my_include | markdownify }}
+      </div>
+    </div>
+  </div>
+</div>

--- a/docs/02-create-page.md
+++ b/docs/02-create-page.md
@@ -1,10 +1,27 @@
 # Create a new page
 
-To create a new page for the website, you need to 
+To create a new page for the website, you need to
 
-* Front matter (for menu item)
-* Translation of page.title -> en.yml
-* create new-page.html
-* create sections.md
+* Create a new HTML page frame inside the website's root directory, e.g. copy the `how-to-vote.html` file to `my-new-page.html`
+* Adopt the [front matter](https://jekyllrb.com/docs/front-matter/) (meta-data) of this new page frame (inside the HTML file):
+   * `layout` selects the header/footer frame from `_layouts/`
+   * `title` is **optional** and should only be given, if this new page shall be visible in the main header- & footer-menus. It specifies the translation key for the new page's title -> this key needs to be added (translated) in `_i18n/en.yml` -> `pages:`
+   * `namespace` is a unique id of this page (same for all languages), and can be used to link to this page via the `translate_link my-new-page` macro
+   * `permalink` is the browser visible URL of this page, should be SEO friendly
 
-TODO
+```
+---
+layout: default
+title: pages.myNewPage
+
+namespace: my-new-page
+permalink: /my-new-page/
+---
+```
+
+* Create the file structure & markdown files needed for your page content, e.g. create a `_i18n/en/my-new-page` folder, which contains `section1.md` & `section2.md`
+   * Include those markdown files inside the HTML page frame via the `translate_file my-new-page/section1.md` macro
+   * Adopt the HTML structure/sections as needed (e.g. via Bootstrap CSS) and create corresponding markdown files inside your `_i18n/en/my-new-page/` folder, which you include into your HTML via the `translate_file` macro.
+* Create an **optional** stylesheet inside `_sass/my-new-page.scss` and import it via `_sass/custom.scss` -> `@import 'my-new-page.scss';`
+   * Also adopt the main CSS class of the `my-new-page.html` page frame (first line of HTML, directly after the front-matter): `<div class="my-new-page">`
+   * This way you can write CSS rules inside `my-new-page.scss`, which only apply for this page, e.g.: `.my-new-page p { color: red }`

--- a/docs/03-pull-request.html
+++ b/docs/03-pull-request.html
@@ -1,0 +1,16 @@
+---
+layout: docs
+
+namespace: docs-pull-request
+permalink: /docs/03-pull-request
+---
+<div class="docs">
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+          {% capture my_include %}{% include_relative 03-pull-request.md %}{% endcapture %}
+          {{ my_include | markdownify }}
+      </div>
+    </div>
+  </div>
+</div>

--- a/docs/04-run-local.html
+++ b/docs/04-run-local.html
@@ -1,0 +1,16 @@
+---
+layout: docs
+
+namespace: docs-run-local
+permalink: /docs/04-run-local
+---
+<div class="docs">
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+          {% capture my_include %}{% include_relative 04-run-local.md %}{% endcapture %}
+          {{ my_include | markdownify }}
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
correctly parsed markdown – additionaly to the hosted version on github

The docs can be accessed after running `jekyll serve`