### PR TITLE
Update header member client link

### DIFF
--- a/_i18n/en/member-client/box2.md
+++ b/_i18n/en/member-client/box2.md
@@ -1,5 +1,5 @@
 ![Transfer](/assets/home/wallet-48x48.svg)
 
-**Transfer Tokens**
+**Review Financials**
 
 (Live)

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -58,7 +58,7 @@
         <a href="{% translate_link why-vote %}#voting-matters" class="btn solid light btn-raised scatter-vote-oneclick">
           {% translate header.vote %}
         </a>
-        <a href="{% translate_link member-client %}" class="btn outline light btn-raised">
+        <a href="https://members.eosdac.io/" class="btn outline light btn-raised">
           {% translate header.mclient %}
         </a>
       </span>


### PR DESCRIPTION
Based on feedback from community members, this PR changes the header link to go directly to the member client instead of an intermediate page (which is still referenced in other places on the site). This PR also cleans that page up and removes the reference to a wallet.